### PR TITLE
Enforcing 2FA for all members of the organisation

### DIFF
--- a/otterdog/eclipse-glsp.jsonnet
+++ b/otterdog/eclipse-glsp.jsonnet
@@ -8,7 +8,6 @@ orgs.newOrg('eclipse-glsp') {
     packages_containers_internal: false,
     packages_containers_public: false,
     readers_can_create_discussions: true,
-    two_factor_requirement: true,
     web_commit_signoff_required: false,
     workflows+: {
       default_workflow_permissions: "write",

--- a/otterdog/eclipse-glsp.jsonnet
+++ b/otterdog/eclipse-glsp.jsonnet
@@ -8,7 +8,7 @@ orgs.newOrg('eclipse-glsp') {
     packages_containers_internal: false,
     packages_containers_public: false,
     readers_can_create_discussions: true,
-    two_factor_requirement: false,
+    two_factor_requirement: true,
     web_commit_signoff_required: false,
     workflows+: {
       default_workflow_permissions: "write",


### PR DESCRIPTION
We're taking steps to further enhance the security of your projects and repositories, as part of our ongoing commitment to cybersecurity.

Following our previous communication on January 14th, shared through the eclipse.org-committers [mailing list](https://www.eclipse.org/lists/eclipse.org-committers/msg01409.html), and detailed in the associated [support ticket](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/477#note_1610474), we are now enabling the requirement for two-factor authentication (2FA) across the entire GitHub organisation of your project.

**We are pleased to report that your organisation was already in full compliance with this new requirement; all members already have 2FA enabled**. Consequently, this policy enforcement will not necessitate any immediate changes on your part. However, it is important to mention that moving forward, all new committers or [contributors](https://www.eclipse.org/projects/handbook/#pmi-contributors), will be required to activate 2FA prior to their invitation to join the GitHub organisation.

Should you have any questions or face any challenges with this change, please do not hesitate to [open a ticket on the HelpDesk](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/new), comment on the [ticket tracking this initiative](https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/477), or just add your comment to this pull request.

Thanks!

/cc @CamilleLetavernier @martin-fleck-at @ndoschek @planger @tortmayr
