### PR TITLE
Fix branch protection rule for glsp-playwright

### DIFF
--- a/otterdog/eclipse-glsp.jsonnet
+++ b/otterdog/eclipse-glsp.jsonnet
@@ -167,7 +167,7 @@ orgs.newOrg('eclipse-glsp') {
         },
       ],
       branch_protection_rules: [
-        orgs.newBranchProtectionRule('master') {
+        orgs.newBranchProtectionRule('main') {
           required_approving_review_count: 0,
         },
       ],


### PR DESCRIPTION
The branch protection rule for glsp-playwright was configured for `master` instead of `main` on accident