### PR TITLE
Remove npm.js repo secret

### DIFF
--- a/otterdog/eclipse-glsp.jsonnet
+++ b/otterdog/eclipse-glsp.jsonnet
@@ -7,11 +7,6 @@ orgs.newOrg('ecd.glsp', 'eclipse-glsp') {
       default_workflow_permissions: "write",
     },
   },
-  secrets+: [
-    orgs.newOrgSecret('NPMJS_TOKEN') {
-      value: "pass:bots/ecd.glsp/npmjs.com/token",
-    },
-  ],
   _repositories+:: [
     orgs.newRepo('glsp') {
       allow_update_branch: false,


### PR DESCRIPTION
Remove the auth token secret for npm.js.
After the switch to trusted publishing (OIDC) its no longer required.