### PR TITLE
Allow direct pushes to glsp-core main temporarily

### DIFF
--- a/otterdog/eclipse-glsp.jsonnet
+++ b/otterdog/eclipse-glsp.jsonnet
@@ -102,6 +102,7 @@ orgs.newOrg('ecd.glsp', 'eclipse-glsp') {
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main') {
           required_approving_review_count: 0,
+          requires_pull_request: false,
         },
       ],
     },


### PR DESCRIPTION
Disable the pull-request requirement on the glsp-core main branch protection rule to permit temporary direct pushes.